### PR TITLE
ci: new action for browserslist update

### DIFF
--- a/.github/workflows/pr-template.md
+++ b/.github/workflows/pr-template.md
@@ -1,0 +1,10 @@
+# Auto-update of supported browsers
+
+**Please check:**
+
+- [ ] `caniuse-lite` version (and only that) is updated in package-lock.json
+- [ ] suitable browsers written to `public/api.json`
+
+When you are happy, approve and merge this PR. :rocket:
+
+To follow up with the GH Pages deployment, checkout the repo and run `npm run deploy` locally.

--- a/.github/workflows/update-browserslist.yml
+++ b/.github/workflows/update-browserslist.yml
@@ -1,0 +1,48 @@
+name: Update Browserslist database
+
+on:
+  schedule:
+    - cron: '0 6 15 * *' # 06:00 on the 15th of every month
+  workflow_dispatch: # or via Github UI
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-browserslist-database:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure git
+        run: |
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14.x
+
+      - name: Install packages
+        run: npm ci
+
+      - name: Update Browserslist database (old way)
+        run: npx browserslist@latest --update-db
+
+      - name: Rebuild API
+        run: npm run build-api
+
+      - name: Add & commit changes
+        uses: EndBug/add-and-commit@v9
+        with:
+          message: 'ci: update browserslist database'
+          new_branch: 'ci/update-browserslist'
+
+      - name: Create PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr create --base "main" --head "ci/update-browserslist" --title "Update browserslist database" --label "ci" --body-file "./.github/workflows/pr-template.md"

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ The app will be available on http://localhost:3000:
 
 There is a 2-step process to make the latest browsers available in the API:
 
+> An update PR will also be opened by an action once per month.
+
 #### 1. Update browserslist db
 
 The following script installs the latest version of `caniuse-lite` in the package-lock.json. Without it, the API can receive outdated browsers. The resulting updated file should be committed.


### PR DESCRIPTION
Following on from #5, this PR adds an action to open the same type of update PR, scheduled to run once a month (I chose the 15th).

The created PR will look like [this one in my temporary fork](https://github.com/oatymart/browserslist-app-tao/pull/2).
The actions run will look like [this one](https://github.com/oatymart/browserslist-app-tao/actions/runs/3086631066/jobs/4991172677).

We'll have to check and merge the automatic PRs manually (to avoid any surprises).