### PR TITLE
fix: define package repository so taoRelease can release it

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,10 @@
         "build-app": "REACT_APP_BUILD_DATE=$(date -I) react-scripts build",
         "update-db": "npx browserslist@latest --update-db"
     },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/oat-sa/browserslist-app-tao.git"
+    },
     "eslintConfig": {
         "extends": [
             "react-app",


### PR DESCRIPTION
`taoRelease npmRelease` fails at the first hurdle since `repository.url` is not defined.

I think this app did not have proper `develop -> main` releases before.